### PR TITLE
[feat] GET api/filter/public 구현 및 DELETE api/filter/{filterId} 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    
+
     testRuntimeOnly 'com.h2database:h2'
     implementation 'mysql:mysql-connector-java:8.0.33'
 
@@ -44,11 +44,18 @@ dependencies {
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
-    
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 
 }
 

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
@@ -1,21 +1,20 @@
 package com.samsungnomads.wheretogo.domain.filter.controller;
 
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterDetailDto;
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterPrivateCreationDto;
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterPrivateOwnDto;
+import com.samsungnomads.wheretogo.domain.filter.dto.*;
 import com.samsungnomads.wheretogo.domain.filter.service.FilterService;
 import com.samsungnomads.wheretogo.global.security.dto.UserDetailsImpl;
 import com.samsungnomads.wheretogo.global.success.SuccessCode;
 import com.samsungnomads.wheretogo.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -41,6 +40,18 @@ public class FilterController implements FilterControllerDocs {
     public ResponseEntity<SuccessResponse<FilterDetailDto>> getFilterDetail(@PathVariable("filterId") Long filterId) {
         FilterDetailDto filterDetailDto = filterService.getFilterDetail(filterId);
         return SuccessResponse.of(SuccessCode.FILTER_DETAIL, filterDetailDto);
+    }
+
+    @GetMapping("/public")
+    public ResponseEntity<SuccessResponse<Slice<FilterPublicDto>>> getPublicFilters(
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) Integer lastLikes,
+            @RequestParam(required = false) LocalDateTime lastUpdatedAt,
+            @PageableDefault(size = 5) Pageable pageable
+    ) {
+        Slice<FilterPublicDto> filterPublicDtos = filterService.getPublicFilters(cursorId, new FilterConditionDto(lastLikes, lastUpdatedAt), pageable);
+        return SuccessResponse.of(SuccessCode.OK, filterPublicDtos);
+
     }
 
 }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
@@ -47,9 +47,11 @@ public class FilterController implements FilterControllerDocs {
             @RequestParam(required = false) Long cursorId,
             @RequestParam(required = false) Integer lastLikes,
             @RequestParam(required = false) LocalDateTime lastUpdatedAt,
+            @RequestParam(required = false) String keyword,
             @PageableDefault(size = 5) Pageable pageable
     ) {
-        Slice<FilterPublicDto> filterPublicDtos = filterService.getPublicFilters(cursorId, new FilterConditionDto(lastLikes, lastUpdatedAt), pageable);
+        FilterConditionDto condition = new FilterConditionDto(lastLikes, lastUpdatedAt, keyword);
+        Slice<FilterPublicDto> filterPublicDtos = filterService.getPublicFilters(cursorId, condition, pageable);
         return SuccessResponse.of(SuccessCode.OK, filterPublicDtos);
 
     }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
@@ -54,4 +54,10 @@ public class FilterController implements FilterControllerDocs {
 
     }
 
+    @DeleteMapping("/private/{filterId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteFilter(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable("filterId") Long filterId) {
+        filterService.deleteFilter(userDetails.getUsername(), filterId);
+        return SuccessResponse.of(SuccessCode.FILTER_DELETE, null);
+    }
+
 }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterConditionDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterConditionDto.java
@@ -1,0 +1,13 @@
+package com.samsungnomads.wheretogo.domain.filter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class FilterConditionDto {
+    private Integer lastLikes;
+    private LocalDateTime lastUpdatedAt;
+}

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterConditionDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterConditionDto.java
@@ -10,4 +10,5 @@ import java.time.LocalDateTime;
 public class FilterConditionDto {
     private Integer lastLikes;
     private LocalDateTime lastUpdatedAt;
+    private String keyword;
 }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterPublicDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterPublicDto.java
@@ -1,0 +1,31 @@
+package com.samsungnomads.wheretogo.domain.filter.dto;
+
+import com.samsungnomads.wheretogo.domain.filter.entity.Filter;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class FilterPublicDto {
+
+    private Long id;
+    private String name;
+    private String creatorNickname;
+    private Integer likes;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static FilterPublicDto from(Filter filter) {
+        return new FilterPublicDto(
+                filter.getId(),
+                filter.getName(),
+                //filter.getCreator().getNickname(),
+                "Abc",
+                filter.getLikes(),
+                filter.getCreatedAt(),
+                filter.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterRequestDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterRequestDto.java
@@ -1,4 +1,0 @@
-package com.samsungnomads.wheretogo.domain.filter.dto;
-
-public class FilterRequestDto {
-}

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/entity/Filter.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/entity/Filter.java
@@ -36,6 +36,9 @@ public class Filter {
     @Column(name = "is_shared")
     private Boolean isShared; // 🔄 공유 여부
 
+    @Column(name = "likes")
+    private Integer likes;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "login_id", referencedColumnName = "login_id", nullable = false)
     private Member creator; // 👤 필터를 제작한 회원

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/repository/FilterRepository.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/repository/FilterRepository.java
@@ -1,11 +1,12 @@
 package com.samsungnomads.wheretogo.domain.filter.repository;
 
 import com.samsungnomads.wheretogo.domain.filter.entity.Filter;
+import com.samsungnomads.wheretogo.domain.filter.repository.querydsl.FilterCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface FilterRepository extends JpaRepository<Filter, Long> {
+public interface FilterRepository extends JpaRepository<Filter, Long>, FilterCustomRepository {
 
     List<Filter> findByCreator_LoginId(String loginId);
 }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/repository/querydsl/FilterCustomRepository.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/repository/querydsl/FilterCustomRepository.java
@@ -1,0 +1,11 @@
+package com.samsungnomads.wheretogo.domain.filter.repository.querydsl;
+
+import com.samsungnomads.wheretogo.domain.filter.dto.FilterConditionDto;
+import com.samsungnomads.wheretogo.domain.filter.dto.FilterPublicDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface FilterCustomRepository {
+
+    Slice<FilterPublicDto> findByConditionWithPageable(Long cursorId, FilterConditionDto condition, Pageable pageable);
+}

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/repository/querydsl/FilterCustomRepositoryImpl.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/repository/querydsl/FilterCustomRepositoryImpl.java
@@ -1,0 +1,99 @@
+package com.samsungnomads.wheretogo.domain.filter.repository.querydsl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.samsungnomads.wheretogo.domain.filter.dto.FilterConditionDto;
+import com.samsungnomads.wheretogo.domain.filter.dto.FilterPublicDto;
+import com.samsungnomads.wheretogo.domain.filter.entity.Filter;
+import com.samsungnomads.wheretogo.global.common.SliceUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.samsungnomads.wheretogo.domain.filter.entity.QFilter.filter;
+
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class FilterCustomRepositoryImpl implements FilterCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<FilterPublicDto> findByConditionWithPageable(Long cursorId, FilterConditionDto condition, Pageable pageable) {
+
+        BooleanExpression whereCondition = createWhereCondition(cursorId, condition, pageable);
+
+        List<Filter> filters = jpaQueryFactory.selectFrom(filter)
+                .where(whereCondition)
+                .limit(SliceUtil.getLimit(pageable))
+                .orderBy(SliceUtil.getOrderSpecifier(pageable))
+                .fetch();
+
+        return SliceUtil.toSlice(pageable, filters, FilterPublicDto::from);
+    }
+
+    private BooleanExpression createWhereCondition(Long cursorId, FilterConditionDto condition, Pageable pageable) {
+
+        if (cursorId == null) {
+            return null;
+        }
+
+        String property = getSortOrder(pageable).getProperty();
+        Sort.Direction direction = getSortOrder(pageable).getDirection();
+
+        if (property.equals("likes")) {
+            return buildLikesCondition(condition.getLastLikes(), cursorId, direction);
+        } else if (property.equals("updatedAt")) {
+            return buildUpdatedAtCondition(condition.getLastUpdatedAt(), cursorId, direction);
+        } else {
+            return buildIdCondition(cursorId, direction);
+        }
+
+    }
+
+    private Sort.Order getSortOrder(Pageable pageable) {
+        return pageable.getSort().stream().findFirst()
+                .orElse(new Sort.Order(Sort.Direction.DESC, "id")); // 기본 정렬
+    }
+
+    private BooleanExpression buildLikesCondition(Integer lastLikes, Long cursorId, Sort.Direction direction) {
+        log.info("buildLikesCondition: lastLikes={}, direction={}", lastLikes, direction);
+        if (lastLikes == null || cursorId == null) return null;
+
+        return direction.isAscending() ?
+                filter.likes.gt(lastLikes)
+                        .or(filter.likes.eq(lastLikes).and(filter.id.gt(cursorId))) :
+                filter.likes.lt(lastLikes)
+                        .or(filter.likes.eq(lastLikes).and(filter.id.lt(cursorId)));
+    }
+
+    private BooleanExpression buildUpdatedAtCondition(LocalDateTime lastUpdatedAt, Long cursorId, Sort.Direction direction) {
+        log.info("buildUpdatedAtCondition: lastUpdatedAt={}, direction={}", lastUpdatedAt, direction);
+        if (lastUpdatedAt == null || cursorId == null) return null;
+
+        return direction.isAscending() ?
+                filter.updatedAt.gt(lastUpdatedAt)
+                        .or(filter.updatedAt.eq(lastUpdatedAt).and(filter.id.gt(cursorId))) :
+                filter.updatedAt.lt(lastUpdatedAt)
+                        .or(filter.updatedAt.eq(lastUpdatedAt).and(filter.id.lt(cursorId)));
+    }
+
+    private BooleanExpression buildIdCondition(Long cursorId, Sort.Direction direction) {
+        log.info("buildIdCondition: cursorId={}, direction={}", cursorId, direction);
+        if (cursorId == null) return null;
+
+        return direction.isAscending() ?
+                filter.id.gt(cursorId) :
+                filter.id.lt(cursorId);
+    }
+
+
+}

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/service/FilterService.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/service/FilterService.java
@@ -59,4 +59,14 @@ public class FilterService {
 
         return filterRepository.findByConditionWithPageable(cursorId, condition, pageable);
     }
+
+    @Transactional
+    public void deleteFilter(String username, Long filterId) {
+        Filter filter = filterRepository.findById(filterId).orElseThrow(() -> new BusinessException(ErrorCode.FILTER_NOT_FOUND));
+        Member member = memberRepository.findByLoginId(username).orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        MemberFilter memberFilter = memberFilterRepository.findByMemberIdAndFilterId(member.getId(), filter.getId()).orElseThrow(() -> new BusinessException(ErrorCode.FILTER_NOT_OWNER));
+
+        memberFilterRepository.delete(memberFilter);
+    }
 }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/service/FilterService.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/service/FilterService.java
@@ -1,8 +1,6 @@
 package com.samsungnomads.wheretogo.domain.filter.service;
 
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterDetailDto;
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterPrivateCreationDto;
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterPrivateOwnDto;
+import com.samsungnomads.wheretogo.domain.filter.dto.*;
 import com.samsungnomads.wheretogo.domain.filter.entity.Filter;
 import com.samsungnomads.wheretogo.domain.filter.repository.FilterRepository;
 import com.samsungnomads.wheretogo.domain.member.entity.Member;
@@ -14,6 +12,8 @@ import com.samsungnomads.wheretogo.global.error.exception.BusinessException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -52,5 +52,11 @@ public class FilterService {
         Filter filter = filterRepository.findById(filterId).orElseThrow(() -> new BusinessException(ErrorCode.FILTER_NOT_FOUND));
 
         return FilterDetailDto.from(filter);
+    }
+
+    @Transactional
+    public Slice<FilterPublicDto> getPublicFilters(Long cursorId, FilterConditionDto condition, Pageable pageable) {
+
+        return filterRepository.findByConditionWithPageable(cursorId, condition, pageable);
     }
 }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/relationship/repository/MemberFilterRepository.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/relationship/repository/MemberFilterRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 회원-필터 매핑 리포지토리
@@ -13,22 +14,26 @@ import java.util.List;
  */
 @Repository
 public interface MemberFilterRepository extends JpaRepository<MemberFilter, MemberFilterId> {
-    
+
     /**
      * 필터 ID로 회원-필터 관계 목록 조회
      * 🔍 특정 필터를 사용하는 모든 회원 관계 조회
      */
     List<MemberFilter> findByFilterId(Long filterId);
-    
+
     /**
      * 회원 ID로 회원-필터 관계 목록 조회
      * 🔍 특정 회원이 접근 가능한 모든 필터 관계 조회
      */
     List<MemberFilter> findByMemberId(Long memberId);
+
+
+    Optional<MemberFilter> findByMemberIdAndFilterId(Long memberId, Long filterId);
     
     /**
      * 회원-필터 관계 존재 여부 확인
      * ✅ 특정 회원과 필터 간의 관계가 존재하는지 확인
      */
     boolean existsByMemberIdAndFilterId(Long memberId, Long filterId);
-} 
+
+}

--- a/src/main/java/com/samsungnomads/wheretogo/global/common/SliceUtil.java
+++ b/src/main/java/com/samsungnomads/wheretogo/global/common/SliceUtil.java
@@ -1,0 +1,57 @@
+package com.samsungnomads.wheretogo.global.common;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.samsungnomads.wheretogo.domain.filter.entity.QFilter.filter;
+
+@Slf4j
+public class SliceUtil {
+    private static final String ORDER_BY_UPDATED_AT = "updatedAt";
+    private static final String ORDER_BY_LIKES = "likes";
+
+    public static int getLimit(Pageable pageable) {
+        return pageable.getPageSize() + 1;
+    }
+
+    public static OrderSpecifier<?> getOrderSpecifier(Pageable pageable) {
+        for (Sort.Order order : pageable.getSort()) {
+
+            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+            return switch (order.getProperty()) {
+                case ORDER_BY_UPDATED_AT -> new OrderSpecifier<>(direction, filter.updatedAt);
+                case ORDER_BY_LIKES -> new OrderSpecifier<>(direction, filter.likes);
+                default -> new OrderSpecifier<>(direction, filter.id);
+            };
+        }
+        return new OrderSpecifier<>(Order.DESC, filter.id);
+    }
+
+    public static <T, R> SliceImpl<R> toSlice(Pageable pageable, List<T> lst, Function<T, R> mapper) {
+
+        // 다음 페이지가 존재하는지 확인: 요청한 pageSize보다 1개 더 가져왔다면 true
+        boolean hasNext = lst.size() > pageable.getPageSize();
+
+        // hasNext가 true인 경우, 실제 반환할 데이터에서는 초과된 마지막 요소 1개 제거
+        if (hasNext) {
+            lst.remove(pageable.getPageSize());
+        }
+
+        // Entity 리스트를 DTO 등으로 변환하고 SliceImpl로 감싸서 리턴
+        return new SliceImpl<>(
+                lst.stream()
+                        .map(mapper) // 예: Diary → DiaryBriefResponse
+                        .collect(Collectors.toList()), // 변환된 리스트
+                pageable, // 요청된 페이징 정보 그대로 전달
+                hasNext   // 다음 페이지 존재 여부 포함
+        );
+    }
+}

--- a/src/main/java/com/samsungnomads/wheretogo/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/samsungnomads/wheretogo/global/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package com.samsungnomads.wheretogo.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/samsungnomads/wheretogo/global/error/ErrorCode.java
+++ b/src/main/java/com/samsungnomads/wheretogo/global/error/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
 
     // 필터 관련 오류
     FILTER_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "필터를 찾을 수 없습니다"),
+    FILTER_NOT_OWNER(HttpStatus.UNAUTHORIZED, "F002", "필터를 소유하고 있지 않습니다"),
 
     // 지하철역 관련 오류
     STATION_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "지하철역을 찾을 수 없습니다");

--- a/src/main/java/com/samsungnomads/wheretogo/global/success/SuccessCode.java
+++ b/src/main/java/com/samsungnomads/wheretogo/global/success/SuccessCode.java
@@ -24,7 +24,8 @@ public enum SuccessCode {
     // 필터 관련
     FILTER_PRIVATE_OWN(HttpStatus.OK, "사용자가 소유한 필터 목록을 성공적으로 조회했습니다."),
     FILTER_PRIVATE_CREATION(HttpStatus.OK, "사용자가 생성한 필터 목록을 성공적으로 조회했습니다."),
-    FILTER_DETAIL(HttpStatus.OK, "필터 상세 정보를 성공적으로 조회했습니다.");
+    FILTER_DETAIL(HttpStatus.OK, "필터 상세 정보를 성공적으로 조회했습니다."),
+    FILTER_DELETE(HttpStatus.OK, "필터를 성공적으로 삭제하였습니다");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 🔥 What’s Changed
- QueryDSL, 커서 기반 페이지네이션으로 api/filter/public 구현.
- DELETE api/filter/{filterId} 구현 

## 🎯 Related Issue
- 없음

## 📋 Checklist
- [x] 중복 코드 없음
- [x] 커밋 룰 준수
- [x] Unit Test 수행
- [x] Postman 테스트
- [ ] 테스트 코드 없음 (이유 명시)
