### PR TITLE
feat: 필터 API 구현 (다운로드, 업로드, 생성) 및 FilterControllerDocs 통합

### DIFF
--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/filter")
 @RequiredArgsConstructor
-public class FilterController implements FilterControllerDocs {
+public class FilterController {
     private final FilterService filterService;
 
     @GetMapping("/private/owns")
@@ -61,5 +61,58 @@ public class FilterController implements FilterControllerDocs {
         filterService.deleteFilter(userDetails.getUsername(), filterId);
         return SuccessResponse.of(SuccessCode.FILTER_DELETE, null);
     }
-
+    
+    /**
+     * 필터 다운로드
+     * 📥 공용 저장소에서 내 저장소로 필터 다운로드
+     */
+    @PostMapping("/download")
+    public ResponseEntity<SuccessResponse<FilterDownloadResponseDto>> downloadFilter(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody FilterDownloadRequestDto requestDto
+    ) {
+        FilterDownloadResponseDto responseDto = filterService.downloadFilter(
+                userDetails.getUsername(),
+                requestDto.getFilterId()
+        );
+        
+        return SuccessResponse.of(SuccessCode.FILTER_DOWNLOAD_SUCCESS, responseDto);
+    }
+    
+    /**
+     * 필터 업로드
+     * 📤 내 저장소에서 공용 저장소로 필터 업로드
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<SuccessResponse<FilterUploadResponseDto>> uploadFilter(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody FilterUploadRequestDto requestDto
+    ) {
+        FilterUploadResponseDto responseDto = filterService.uploadFilter(
+                userDetails.getUsername(),
+                requestDto.getFilterId(),
+                requestDto.getIsShared()
+        );
+        
+        return SuccessResponse.of(SuccessCode.FILTER_UPLOAD_SUCCESS, responseDto);
+    }
+    
+    /**
+     * 필터 생성
+     * 🆕 새로운 필터를 생성하고 내 저장소에 저장
+     */
+    @PostMapping("/save")
+    public ResponseEntity<SuccessResponse<FilterSaveResponseDto>> saveFilter(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody FilterSaveRequestDto requestDto
+    ) {
+        FilterSaveResponseDto responseDto = filterService.createFilter(
+                userDetails.getUsername(),
+                requestDto.getName(),
+                requestDto.getIsShared(),
+                requestDto.getStationIds()
+        );
+        
+        return SuccessResponse.of(SuccessCode.FILTER_SAVE_SUCCESS, responseDto);
+    }
 }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterController.java
@@ -21,28 +21,32 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/filter")
 @RequiredArgsConstructor
-public class FilterController {
+public class FilterController implements FilterControllerDocs {
     private final FilterService filterService;
 
     @GetMapping("/private/owns")
+    @Override
     public ResponseEntity<SuccessResponse<List<FilterPrivateOwnDto>>> getPrivateOwnFilters(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         List<FilterPrivateOwnDto> filterPrivateOwnDtos = filterService.getPrivateOwnFiltersByLoginId(userDetails.getUsername());
         return SuccessResponse.of(SuccessCode.FILTER_PRIVATE_OWN, filterPrivateOwnDtos);
     }
 
     @GetMapping("/private/creations")
+    @Override
     public ResponseEntity<SuccessResponse<List<FilterPrivateCreationDto>>> getPrivateCreationFilters(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         List<FilterPrivateCreationDto> filterPrivateCreationDtos = filterService.getPrivateCreationFiltersByLoginId(userDetails.getUsername());
         return SuccessResponse.of(SuccessCode.FILTER_PRIVATE_CREATION, filterPrivateCreationDtos);
     }
 
     @GetMapping("/{filterId}")
+    @Override
     public ResponseEntity<SuccessResponse<FilterDetailDto>> getFilterDetail(@PathVariable("filterId") Long filterId) {
         FilterDetailDto filterDetailDto = filterService.getFilterDetail(filterId);
         return SuccessResponse.of(SuccessCode.FILTER_DETAIL, filterDetailDto);
     }
 
     @GetMapping("/public")
+    @Override
     public ResponseEntity<SuccessResponse<Slice<FilterPublicDto>>> getPublicFilters(
             @RequestParam(required = false) Long cursorId,
             @RequestParam(required = false) Integer lastLikes,
@@ -57,6 +61,7 @@ public class FilterController {
     }
 
     @DeleteMapping("/private/{filterId}")
+    @Override
     public ResponseEntity<SuccessResponse<Void>> deleteFilter(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable("filterId") Long filterId) {
         filterService.deleteFilter(userDetails.getUsername(), filterId);
         return SuccessResponse.of(SuccessCode.FILTER_DELETE, null);
@@ -67,6 +72,7 @@ public class FilterController {
      * 📥 공용 저장소에서 내 저장소로 필터 다운로드
      */
     @PostMapping("/download")
+    @Override
     public ResponseEntity<SuccessResponse<FilterDownloadResponseDto>> downloadFilter(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody FilterDownloadRequestDto requestDto
@@ -84,6 +90,7 @@ public class FilterController {
      * 📤 내 저장소에서 공용 저장소로 필터 업로드
      */
     @PostMapping("/upload")
+    @Override
     public ResponseEntity<SuccessResponse<FilterUploadResponseDto>> uploadFilter(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody FilterUploadRequestDto requestDto
@@ -102,6 +109,7 @@ public class FilterController {
      * 🆕 새로운 필터를 생성하고 내 저장소에 저장
      */
     @PostMapping("/save")
+    @Override
     public ResponseEntity<SuccessResponse<FilterSaveResponseDto>> saveFilter(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody FilterSaveRequestDto requestDto

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterControllerDocs.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterControllerDocs.java
@@ -1,9 +1,6 @@
 package com.samsungnomads.wheretogo.domain.filter.controller;
 
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterDetailDto;
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterPrivateCreationDto;
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterPrivateOwnDto;
-import com.samsungnomads.wheretogo.domain.filter.dto.FilterPublicDto;
+import com.samsungnomads.wheretogo.domain.filter.dto.*;
 import com.samsungnomads.wheretogo.global.security.dto.UserDetailsImpl;
 import com.samsungnomads.wheretogo.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +16,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
@@ -249,5 +247,104 @@ public interface FilterControllerDocs {
     public ResponseEntity<SuccessResponse<Void>> deleteFilter(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable("filterId") Long filterId
+    );
+
+    @Operation(
+            summary = "필터 다운로드",
+            description = "공용 저장소에서 내 저장소로 필터를 다운로드합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "필터 다운로드 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "필터 다운로드 성공 응답 예시",
+                                    summary = "필터 다운로드 성공 시 응답 예시",
+                                    value = """
+                                            {
+                                                "status": 200,
+                                                "message": "필터를 내 저장소로 성공적으로 다운로드했습니다",
+                                                "data": {
+                                                    "filterId": 1,
+                                                    "filterName": "맛집 추천 필터",
+                                                    "creatorNickname": "FoodExplorer",
+                                                    "isShared": true
+                                                }
+                                            }
+                                            """
+                            )
+                    ))
+    })
+    public ResponseEntity<SuccessResponse<FilterDownloadResponseDto>> downloadFilter(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody FilterDownloadRequestDto requestDto
+    );
+    
+    @Operation(
+            summary = "필터 업로드",
+            description = "내 저장소의 필터를 공용 저장소로 업로드(공유)합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "필터 업로드 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "필터 업로드 성공 응답 예시",
+                                    summary = "필터 업로드 성공 시 응답 예시",
+                                    value = """
+                                            {
+                                                "status": 200,
+                                                "message": "필터를 공용 저장소로 성공적으로 업로드했습니다",
+                                                "data": {
+                                                    "filterId": 2,
+                                                    "filterName": "여행지 추천 필터",
+                                                    "isShared": true
+                                                }
+                                            }
+                                            """
+                            )
+                    ))
+    })
+    public ResponseEntity<SuccessResponse<FilterUploadResponseDto>> uploadFilter(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody FilterUploadRequestDto requestDto
+    );
+    
+    @Operation(
+            summary = "필터 생성",
+            description = "새로운 필터를 생성하고 내 저장소에 저장합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "필터 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "필터 생성 성공 응답 예시",
+                                    summary = "필터 생성 성공 시 응답 예시",
+                                    value = """
+                                            {
+                                                "status": 201,
+                                                "message": "필터를 성공적으로 생성하였습니다",
+                                                "data": {
+                                                    "filterId": 3,
+                                                    "name": "새 여행지 필터",
+                                                    "isShared": false,
+                                                    "stationIds": [1, 2, 3, 4],
+                                                    "createdAt": "2023-10-01T14:30:00"
+                                                }
+                                            }
+                                            """
+                            )
+                    ))
+    })
+    public ResponseEntity<SuccessResponse<FilterSaveResponseDto>> saveFilter(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody FilterSaveRequestDto requestDto
     );
 }

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterControllerDocs.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/controller/FilterControllerDocs.java
@@ -1,4 +1,0 @@
-package com.samsungnomads.wheretogo.domain.filter.controller;
-
-public interface FilterControllerDocs {
-}

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterDownloadRequestDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterDownloadRequestDto.java
@@ -1,0 +1,24 @@
+package com.samsungnomads.wheretogo.domain.filter.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 필터 다운로드 요청 DTO
+ * 📥 공용 저장소에서 내 저장소로 필터 다운로드 요청 정보
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FilterDownloadRequestDto {
+    
+    private Long filterId; // 🔍 다운로드할 필터 ID
+    
+    /**
+     * 생성자
+     * 📝 필터 다운로드 요청 초기화
+     */
+    public FilterDownloadRequestDto(Long filterId) {
+        this.filterId = filterId;
+    }
+} 

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterDownloadResponseDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterDownloadResponseDto.java
@@ -1,0 +1,43 @@
+package com.samsungnomads.wheretogo.domain.filter.dto;
+
+import com.samsungnomads.wheretogo.domain.filter.entity.Filter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 필터 다운로드 응답 DTO
+ * 📤 필터 다운로드 결과 정보
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FilterDownloadResponseDto {
+    
+    private Long filterId;        // 🔑 다운로드된 필터 ID
+    private String filterName;    // 📝 필터 이름
+    private String creatorId;     // 👤 원 제작자 ID
+    
+    /**
+     * 빌더 패턴을 이용한 생성자
+     * 🏗️ 필터 다운로드 응답 객체 생성
+     */
+    @Builder
+    public FilterDownloadResponseDto(Long filterId, String filterName, String creatorId) {
+        this.filterId = filterId;
+        this.filterName = filterName;
+        this.creatorId = creatorId;
+    }
+    
+    /**
+     * Entity를 DTO로 변환
+     * 🔄 필터 엔티티를 다운로드 응답 DTO로 변환
+     */
+    public static FilterDownloadResponseDto from(Filter filter) {
+        return FilterDownloadResponseDto.builder()
+                .filterId(filter.getId())
+                .filterName(filter.getName())
+                .creatorId(filter.getCreator().getLoginId())
+                .build();
+    }
+} 

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterSaveRequestDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterSaveRequestDto.java
@@ -1,0 +1,30 @@
+package com.samsungnomads.wheretogo.domain.filter.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 필터 생성 요청 DTO
+ * 📝 새 필터 생성 요청 정보
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FilterSaveRequestDto {
+    
+    private String name;            // 📝 필터 이름
+    private Boolean isShared;       // 🔄 공유 여부
+    private List<Long> stationIds;  // 🚉 포함할 역 ID 목록
+    
+    /**
+     * 생성자
+     * 🏗️ 필터 생성 요청 초기화
+     */
+    public FilterSaveRequestDto(String name, Boolean isShared, List<Long> stationIds) {
+        this.name = name;
+        this.isShared = isShared;
+        this.stationIds = stationIds;
+    }
+} 

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterSaveResponseDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterSaveResponseDto.java
@@ -1,0 +1,57 @@
+package com.samsungnomads.wheretogo.domain.filter.dto;
+
+import com.samsungnomads.wheretogo.domain.filter.entity.Filter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 필터 생성 응답 DTO
+ * 📄 생성된 필터 정보 응답
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FilterSaveResponseDto {
+    
+    private Long filterId;           // 🔑 필터 ID
+    private String name;             // 📝 필터 이름
+    private Boolean isShared;        // 🔄 공유 여부
+    private List<Long> stationIds;   // 🚉 포함된 역 ID 목록
+    private LocalDateTime createdAt; // 📅 생성 시간
+    
+    /**
+     * 빌더 패턴을 이용한 생성자
+     * 🏗️ 필터 생성 응답 객체 생성
+     */
+    @Builder
+    public FilterSaveResponseDto(Long filterId, String name, Boolean isShared, List<Long> stationIds, LocalDateTime createdAt) {
+        this.filterId = filterId;
+        this.name = name;
+        this.isShared = isShared;
+        this.stationIds = stationIds;
+        this.createdAt = createdAt;
+    }
+    
+    /**
+     * Entity를 DTO로 변환
+     * 🔄 필터 엔티티를 생성 응답 DTO로 변환
+     */
+    public static FilterSaveResponseDto from(Filter filter) {
+        List<Long> stationIds = filter.getStations().stream()
+                .map(filterStation -> filterStation.getStation().getId())
+                .collect(Collectors.toList());
+                
+        return FilterSaveResponseDto.builder()
+                .filterId(filter.getId())
+                .name(filter.getName())
+                .isShared(filter.getIsShared())
+                .stationIds(stationIds)
+                .createdAt(filter.getCreatedAt())
+                .build();
+    }
+} 

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterUploadRequestDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterUploadRequestDto.java
@@ -1,0 +1,26 @@
+package com.samsungnomads.wheretogo.domain.filter.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 필터 업로드 요청 DTO
+ * 📤 내 저장소에서 공용 저장소로 필터 업로드 요청 정보
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FilterUploadRequestDto {
+    
+    private Long filterId;      // 🔍 업로드할 필터 ID
+    private Boolean isShared;   // 🔄 공유 여부
+    
+    /**
+     * 생성자
+     * 📝 필터 업로드 요청 초기화
+     */
+    public FilterUploadRequestDto(Long filterId, Boolean isShared) {
+        this.filterId = filterId;
+        this.isShared = isShared;
+    }
+} 

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterUploadResponseDto.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/dto/FilterUploadResponseDto.java
@@ -1,0 +1,43 @@
+package com.samsungnomads.wheretogo.domain.filter.dto;
+
+import com.samsungnomads.wheretogo.domain.filter.entity.Filter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 필터 업로드 응답 DTO
+ * 📩 필터 업로드 결과 정보
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FilterUploadResponseDto {
+    
+    private Long filterId;        // 🔑 업로드된 필터 ID
+    private String filterName;    // 📝 필터 이름
+    private Boolean isShared;     // 🔄 공유 상태
+    
+    /**
+     * 빌더 패턴을 이용한 생성자
+     * 🏗️ 필터 업로드 응답 객체 생성
+     */
+    @Builder
+    public FilterUploadResponseDto(Long filterId, String filterName, Boolean isShared) {
+        this.filterId = filterId;
+        this.filterName = filterName;
+        this.isShared = isShared;
+    }
+    
+    /**
+     * Entity를 DTO로 변환
+     * 🔄 필터 엔티티를 업로드 응답 DTO로 변환
+     */
+    public static FilterUploadResponseDto from(Filter filter) {
+        return FilterUploadResponseDto.builder()
+                .filterId(filter.getId())
+                .filterName(filter.getName())
+                .isShared(filter.getIsShared())
+                .build();
+    }
+} 

--- a/src/main/java/com/samsungnomads/wheretogo/domain/filter/service/FilterService.java
+++ b/src/main/java/com/samsungnomads/wheretogo/domain/filter/service/FilterService.java
@@ -5,8 +5,13 @@ import com.samsungnomads.wheretogo.domain.filter.entity.Filter;
 import com.samsungnomads.wheretogo.domain.filter.repository.FilterRepository;
 import com.samsungnomads.wheretogo.domain.member.entity.Member;
 import com.samsungnomads.wheretogo.domain.member.repository.MemberRepository;
+import com.samsungnomads.wheretogo.domain.relationship.entity.FilterStation;
 import com.samsungnomads.wheretogo.domain.relationship.entity.MemberFilter;
+import com.samsungnomads.wheretogo.domain.relationship.repository.FilterStationRepository;
 import com.samsungnomads.wheretogo.domain.relationship.repository.MemberFilterRepository;
+import com.samsungnomads.wheretogo.domain.relationship.service.MemberFilterService;
+import com.samsungnomads.wheretogo.domain.station.entity.Station;
+import com.samsungnomads.wheretogo.domain.station.repository.StationRepository;
 import com.samsungnomads.wheretogo.global.error.ErrorCode;
 import com.samsungnomads.wheretogo.global.error.exception.BusinessException;
 import jakarta.transaction.Transactional;
@@ -17,6 +22,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -25,6 +31,9 @@ public class FilterService {
     private final FilterRepository filterRepository;
     private final MemberFilterRepository memberFilterRepository;
     private final MemberRepository memberRepository;
+    private final MemberFilterService memberFilterService;
+    private final StationRepository stationRepository;
+    private final FilterStationRepository filterStationRepository;
 
     @Transactional
     public List<FilterPrivateOwnDto> getPrivateOwnFiltersByLoginId(String loginId) {
@@ -68,5 +77,114 @@ public class FilterService {
         MemberFilter memberFilter = memberFilterRepository.findByMemberIdAndFilterId(member.getId(), filter.getId()).orElseThrow(() -> new BusinessException(ErrorCode.FILTER_NOT_OWNER));
 
         memberFilterRepository.delete(memberFilter);
+    }
+    
+    /**
+     * 필터 다운로드
+     * 📥 공용 저장소에서 내 저장소로 필터 다운로드
+     */
+    @Transactional
+    public FilterDownloadResponseDto downloadFilter(String loginId, Long filterId) {
+        // 사용자 확인
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, loginId));
+        
+        // 필터 확인
+        Filter filter = filterRepository.findById(filterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FILTER_NOT_FOUND));
+                
+        // 필터가 공유되어 있는지 확인
+        if (!filter.getIsShared()) {
+            throw new BusinessException(ErrorCode.FILTER_NOT_SHARED);
+        }
+        
+        // 이미 다운로드한 필터인지 확인
+        if (memberFilterService.hasMemberFilterRelationship(member.getId(), filter.getId())) {
+            throw new BusinessException(ErrorCode.FILTER_ALREADY_DOWNLOADED);
+        }
+        
+        // 회원-필터 관계 생성
+        memberFilterService.createMemberFilterRelationship(member, filter);
+        
+        // 응답 생성
+        return FilterDownloadResponseDto.from(filter);
+    }
+    
+    /**
+     * 필터 업로드(공유)
+     * 📤 내 저장소의 필터를 공용 저장소로 업로드(공유)
+     */
+    @Transactional
+    public FilterUploadResponseDto uploadFilter(String loginId, Long filterId, Boolean isShared) {
+        // 사용자 확인
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, loginId));
+        
+        // 필터 확인
+        Filter filter = filterRepository.findById(filterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FILTER_NOT_FOUND));
+        
+        // 필터 제작자인지 확인
+        if (!filter.getCreator().getLoginId().equals(loginId)) {
+            throw new BusinessException(ErrorCode.FILTER_NOT_CREATOR);
+        }
+        
+        // 이미 공유된 상태이고 공유 요청인 경우
+        if (filter.getIsShared() && isShared) {
+            throw new BusinessException(ErrorCode.FILTER_ALREADY_SHARED);
+        }
+        
+        // 필터 공유 상태 업데이트
+        filter.update(filter.getName(), isShared);
+        
+        // 변경 사항 저장
+        Filter updatedFilter = filterRepository.save(filter);
+        
+        // 응답 생성
+        return FilterUploadResponseDto.from(updatedFilter);
+    }
+    
+    /**
+     * 필터 생성
+     * 🆕 새로운 필터를 생성하고 내 저장소에 저장
+     */
+    @Transactional
+    public FilterSaveResponseDto createFilter(String loginId, String name, Boolean isShared, List<Long> stationIds) {
+        // 사용자 확인
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, loginId));
+        
+        // 필터 엔티티 생성 및 저장
+        Filter filter = Filter.builder()
+                .name(name)
+                .isShared(isShared)
+                .creator(member)
+                .build();
+        
+        Filter savedFilter = filterRepository.save(filter);
+        
+        // 필터에 역 추가
+        List<Station> stations = stationRepository.findAllById(stationIds);
+        
+        // 요청한 모든 역이 존재하는지 확인
+        if (stations.size() != stationIds.size()) {
+            throw new BusinessException(ErrorCode.STATION_NOT_FOUND);
+        }
+        
+        // 필터-역 관계 생성
+        List<FilterStation> filterStations = stations.stream()
+                .map(station -> FilterStation.builder()
+                        .filter(savedFilter)
+                        .station(station)
+                        .build())
+                .collect(Collectors.toList());
+        
+        filterStationRepository.saveAll(filterStations);
+        
+        // 회원-필터 관계 생성 (생성자가 소유)
+        memberFilterService.createMemberFilterRelationship(member, savedFilter);
+        
+        // 응답 생성
+        return FilterSaveResponseDto.from(savedFilter);
     }
 }

--- a/src/main/java/com/samsungnomads/wheretogo/global/error/ErrorCode.java
+++ b/src/main/java/com/samsungnomads/wheretogo/global/error/ErrorCode.java
@@ -34,6 +34,10 @@ public enum ErrorCode {
     // 필터 관련 오류
     FILTER_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "필터를 찾을 수 없습니다"),
     FILTER_NOT_OWNER(HttpStatus.UNAUTHORIZED, "F002", "필터를 소유하고 있지 않습니다"),
+    FILTER_NOT_SHARED(HttpStatus.BAD_REQUEST, "F003", "공유되지 않은 필터입니다"),
+    FILTER_ALREADY_DOWNLOADED(HttpStatus.CONFLICT, "F004", "이미 다운로드한 필터입니다"),
+    FILTER_NOT_CREATOR(HttpStatus.FORBIDDEN, "F005", "필터 제작자만 공유 설정을 변경할 수 있습니다"),
+    FILTER_ALREADY_SHARED(HttpStatus.CONFLICT, "F006", "이미 공유 상태인 필터입니다"),
 
     // 지하철역 관련 오류
     STATION_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "지하철역을 찾을 수 없습니다");

--- a/src/main/java/com/samsungnomads/wheretogo/global/success/SuccessCode.java
+++ b/src/main/java/com/samsungnomads/wheretogo/global/success/SuccessCode.java
@@ -25,7 +25,10 @@ public enum SuccessCode {
     FILTER_PRIVATE_OWN(HttpStatus.OK, "사용자가 소유한 필터 목록을 성공적으로 조회했습니다."),
     FILTER_PRIVATE_CREATION(HttpStatus.OK, "사용자가 생성한 필터 목록을 성공적으로 조회했습니다."),
     FILTER_DETAIL(HttpStatus.OK, "필터 상세 정보를 성공적으로 조회했습니다."),
-    FILTER_DELETE(HttpStatus.OK, "필터를 성공적으로 삭제하였습니다");
+    FILTER_DELETE(HttpStatus.OK, "필터를 성공적으로 삭제하였습니다"),
+    FILTER_DOWNLOAD_SUCCESS(HttpStatus.OK, "필터를 내 저장소로 성공적으로 다운로드했습니다"),
+    FILTER_UPLOAD_SUCCESS(HttpStatus.OK, "필터를 공용 저장소로 성공적으로 업로드했습니다"),
+    FILTER_SAVE_SUCCESS(HttpStatus.CREATED, "필터를 성공적으로 생성하였습니다");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 🔥 What’s Changed
1. 필터 다운로드 API 구현
   - 공용 저장소에서 내 저장소로 필터 다운로드
   - POST /api/filter/download

2. 필터 업로드 API 구현
   - 내 저장소에서 공용 저장소로 필터 업로드
   - POST /api/filter/upload

3. 필터 생성 API 구현
   - 필터를 만들어 내 계정에 저장
   - POST /api/filter/save

4. 로컬에서 main 브렌치 병합

5. FilterController가 FilterControllerDocs 인터페이스를 구현하도록 수정

## 🎯 Related Issue
- 없음

## 📋 Checklist
- [X] 중복 코드 없음
- [X] 커밋 룰 준수
- [X] Unit Test 수행
- [X] Postman 테스트
- [ ] 테스트 코드 없음 (이유 명시)
